### PR TITLE
Add automatic chart refresh

### DIFF
--- a/server/index.html
+++ b/server/index.html
@@ -55,17 +55,20 @@
 
     <div class="footer">&copy; 2025 pszczol.one.pl by peterwolf.pl </div>
 <script>
-    fetch('data.php')
-      .then(res => {
-        if (res.status === 403) {
-          window.location.href = 'login.php';
-          throw new Error('Unauthorized');
-        }
-        return res.json();
-      })
-      .then(data => {
+    let chart;
+
+    async function loadData() {
+      const res = await fetch('data.php');
+      if (res.status === 403) {
+        window.location.href = 'login.php';
+        return;
+      }
+
+      const data = await res.json();
+
+      if (!chart) {
         const ctx = document.getElementById('ulChart').getContext('2d');
-        new Chart(ctx, {
+        chart = new Chart(ctx, {
           type: 'line',
           data: {
             labels: data.timestamps,
@@ -103,8 +106,15 @@
             }
           }
         });
-      })
-      .catch(err => console.error(err));
+      } else {
+        chart.data.labels = data.timestamps;
+        chart.data.datasets[0].data = data.weights;
+        chart.update();
+      }
+    }
+
+    loadData();
+    setInterval(loadData, 10000);
 </script>
 </body>
 

--- a/server/index2.php
+++ b/server/index2.php
@@ -18,11 +18,18 @@ if (!isset($_SESSION['logged_in'])) {
 <a href="logout.php">Wyloguj</a>
 
 <script>
-fetch('data.php')
-    .then(response => response.json())
-    .then(data => {
+let chart;
+
+async function loadData() {
+    const res = await fetch('data.php');
+    if (!res.ok) {
+        return;
+    }
+    const data = await res.json();
+
+    if (!chart) {
         const ctx = document.getElementById('chart').getContext('2d');
-        new Chart(ctx, {
+        chart = new Chart(ctx, {
             type: 'line',
             data: {
                 labels: data.timestamps,
@@ -40,7 +47,15 @@ fetch('data.php')
                 }
             }
         });
-    });
+    } else {
+        chart.data.labels = data.timestamps;
+        chart.data.datasets[0].data = data.weights;
+        chart.update();
+    }
+}
+
+loadData();
+setInterval(loadData, 10000);
 </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- refresh the weight chart every 10 seconds
- update both main pages to use the new reload code

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68672b5b2b5c8320b494913e6f5b34b2