### PR TITLE
Implement configurable firmware updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
 client - esp32 
 
-server - website 
+server - website
+
+Now includes `setup.php` for changing firmware update settings and loop delay.

--- a/client/sketch_jun29a11111111111_22222.ino
+++ b/client/sketch_jun29a11111111111_22222.ino
@@ -2,8 +2,11 @@
 #include <HTTPClient.h>
 #include "HX711.h"
 #include <Update.h>
+#include <ArduinoJson.h>
 
 const char* firmware_url = "http://pszczol.one.pl/firmware/esp32.bin";
+const char* config_url = "http://pszczol.one.pl/settings.json";
+const char* report_url = "http://pszczol.one.pl/api/report_update.php";
 const char* ssid = "AirPortExtreme";
 const char* password = "Flash255";
 const char* serverName = "http://pszczol.one.pl/api/add.php/";
@@ -13,16 +16,20 @@ HX711 scale;
 uint8_t dataPin = 16;
 uint8_t clockPin = 4;
 float previous = 0;
+bool firmwareUpdateFlag = false;
+int loopDelay = 10;
 
-void checkFirmwareUpdate() {
+void reportUpdate(bool success);
+
+bool checkFirmwareUpdate() {
   WiFiClient client;
   HTTPClient http;
- Serial.println(" ");
+  Serial.println(" ");
   Serial.println("Sprawdzanie aktualizacji...");
   http.begin(client, firmware_url);
 
-
   int httpCode = http.GET();
+  bool success = false;
 
   if (httpCode == 200) {
     int len = http.getSize();
@@ -32,22 +39,50 @@ void checkFirmwareUpdate() {
       size_t written = Update.writeStream(*stream);
 
       if (written == len && Update.end()) {
-         Serial.println(" ");
+        Serial.println(" ");
         Serial.println("Aktualizacja zakończona sukcesem, restartuję...");
-        ESP.restart();
+        success = true;
       } else {
         Serial.println("Błąd aktualizacji: " + String(Update.getError()));
       }
     } else {
       Serial.println("Nie można rozpocząć aktualizacji.");
-    
     }
   } else {
     Serial.println("Brak aktualizacji. ");
-     Serial.println(" ");
+    Serial.println(" ");
   }
-http.end();
-   Serial.println(" ");
+  http.end();
+  reportUpdate(success);
+  if (success) {
+    ESP.restart();
+  }
+  return success;
+}
+
+void fetchConfig() {
+  HTTPClient http;
+  http.begin(config_url);
+  int httpCode = http.GET();
+  if (httpCode == 200) {
+    String payload = http.getString();
+    StaticJsonDocument<200> doc;
+    DeserializationError err = deserializeJson(doc, payload);
+    if (!err) {
+      firmwareUpdateFlag = doc["firmwareUpdate"];
+      loopDelay = doc["loopDelay"];
+    }
+  }
+  http.end();
+}
+
+void reportUpdate(bool success) {
+  HTTPClient http;
+  http.begin(report_url);
+  http.addHeader("Content-Type", "application/json");
+  String payload = String("{\"success\":") + (success ? "true" : "false") + "}";
+  http.POST(payload);
+  http.end();
 }
 
 void setup() {
@@ -69,7 +104,7 @@ void setup() {
   scale.set_scale(-25.353687);
   scale.tare();
 
-  
+  fetchConfig();
 }
 
 void loop() {
@@ -79,6 +114,12 @@ void loop() {
     WiFi.reconnect();
     delay(5000);
     return;
+  }
+
+  fetchConfig();
+
+  if (firmwareUpdateFlag) {
+    checkFirmwareUpdate();
   }
 
   float weight = getStableWeight();
@@ -107,10 +148,8 @@ void loop() {
 //  Serial.println(" ");
 //  https.end();
  delay(600);
-http.end();
- delay(6000*5);
- checkFirmwareUpdate();
- delay(6000*5*5);
+  http.end();
+  delay(loopDelay * 1000);
 }
 
 float getStableWeight() {

--- a/server/api/report_update.php
+++ b/server/api/report_update.php
@@ -1,0 +1,17 @@
+<?php
+include '../includes/config.php';
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $json = file_get_contents('php://input');
+    $data = json_decode($json, true);
+    $logFile = __DIR__ . '/../update_log.txt';
+    $success = isset($data['success']) && $data['success'];
+    $message = $data['message'] ?? '';
+    $entry = date('c') . ' ' . ($success ? 'OK' : 'FAIL') . ' ' . $message . "\n";
+    file_put_contents($logFile, $entry, FILE_APPEND);
+    echo json_encode(['status' => 'received']);
+} else {
+    http_response_code(405);
+    echo json_encode(['error' => 'Invalid method']);
+}
+?>

--- a/server/settings.json
+++ b/server/settings.json
@@ -1,0 +1,4 @@
+{
+  "firmwareUpdate": false,
+  "loopDelay": 10
+}

--- a/server/setup.php
+++ b/server/setup.php
@@ -1,0 +1,56 @@
+<?php
+session_start();
+if (!isset($_SESSION['logged_in'])) {
+    header('Location: login.php');
+    exit();
+}
+
+$configFile = __DIR__ . '/settings.json';
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $firmwareUpdate = isset($_POST['firmwareUpdate']);
+    $loopDelay = intval($_POST['loopDelay']);
+    $config = [
+        'firmwareUpdate' => $firmwareUpdate,
+        'loopDelay' => $loopDelay
+    ];
+    file_put_contents($configFile, json_encode($config));
+    $message = 'Zapisano konfigurację.';
+} else {
+    if (file_exists($configFile)) {
+        $config = json_decode(file_get_contents($configFile), true);
+        $firmwareUpdate = $config['firmwareUpdate'];
+        $loopDelay = $config['loopDelay'];
+    } else {
+        $firmwareUpdate = false;
+        $loopDelay = 10;
+    }
+}
+?>
+<!DOCTYPE html>
+<html lang="pl">
+<head>
+    <meta charset="UTF-8">
+    <title>Ustawienia</title>
+</head>
+<body>
+<?php if(isset($message)) echo "<p>$message</p>"; ?>
+<form method="post">
+    <label>
+        <input type="checkbox" name="firmwareUpdate" <?php if($firmwareUpdate) echo 'checked'; ?>>
+        firmwareUPDATE
+    </label><br>
+    <label>Delay pętli:
+        <select name="loopDelay">
+            <option value="10" <?php if($loopDelay==10) echo 'selected'; ?>>10s</option>
+            <option value="30" <?php if($loopDelay==30) echo 'selected'; ?>>30s</option>
+            <option value="60" <?php if($loopDelay==60) echo 'selected'; ?>>60s</option>
+            <option value="600" <?php if($loopDelay==600) echo 'selected'; ?>>600s</option>
+            <option value="3600" <?php if($loopDelay==3600) echo 'selected'; ?>>3600s</option>
+        </select>
+    </label><br>
+    <button type="submit">SETUP</button>
+</form>
+<p><a href="index2.php">Powrót</a></p>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add *setup.php* for selecting firmware update and loop delay
- persist configuration in `settings.json`
- allow ESP32 to report firmware update status via new API endpoint
- update sample ESP32 sketches to poll configuration and use it at runtime
- document the new setup script

## Testing
- `php -v` *(fails: command not found)*
- `arduino-cli version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867532c71988320891ffb75feae59fc