### PR TITLE
Add multi-board support

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,10 @@ This project contains two parts:
 - **client** – ESP32 sketch for the beehive scale
 - **server** – PHP website with API endpoints
 
-The setup page (`server/setup.php`) lets you configure WiFi credentials and the
-board ID stored in `server/settings.json`.
+The setup page (`server/setup.php`) lets you configure WiFi credentials and
+other settings. It now displays four separate forms so you can adjust each
+board's configuration individually. All values are saved in
+`server/settings.json`.
 
 `server/settings.json` now holds configuration for four boards (IDs 1–4). Each
 device reads its section based on its compiled `BOARD_ID` value.

--- a/README.md
+++ b/README.md
@@ -6,6 +6,9 @@ This project contains two parts:
 The setup page (`server/setup.php`) lets you configure WiFi credentials and the
 board ID stored in `server/settings.json`.
 
+`server/settings.json` now holds configuration for four boards (IDs 1–4). Each
+device reads its section based on its compiled `BOARD_ID` value.
+
 `index2.php` mirrors the main `index.html` page but adds a link to the setup
 form and allows you to choose the chart colour and type. The page displays four
 charts so you can monitor up to four boards simultaneously.

--- a/server/index2.php
+++ b/server/index2.php
@@ -68,16 +68,16 @@ if (!isset($_SESSION['logged_in'])) {
             <button id="saveStyle" class="btn btn-sm btn-primary ms-3">Zapisz</button>
         </div>
         <div class="row">
-            <div class="col-md-6 mb-4">
+            <div class="col-6 mb-4">
                 <div class="chart-container"><canvas id="chart1"></canvas></div>
             </div>
-            <div class="col-md-6 mb-4">
+            <div class="col-6 mb-4">
                 <div class="chart-container"><canvas id="chart2"></canvas></div>
             </div>
-            <div class="col-md-6 mb-4">
+            <div class="col-6 mb-4">
                 <div class="chart-container"><canvas id="chart3"></canvas></div>
             </div>
-            <div class="col-md-6 mb-4">
+            <div class="col-6 mb-4">
                 <div class="chart-container"><canvas id="chart4"></canvas></div>
             </div>
         </div>

--- a/server/settings.json
+++ b/server/settings.json
@@ -1,9 +1,40 @@
 {
-  "firmwareUpdate": false,
-  "loopDelay": 10,
-  "offset": -598696,
-  "scale": -25.353687,
-  "wifi_ssid": "AirPortExtreme",
-  "wifi_password": "Flash255",
-  "board_id": 1
+  "boards": [
+    {
+      "board_id": 1,
+      "firmwareUpdate": false,
+      "loopDelay": 10,
+      "offset": -598696,
+      "scale": -25.353687,
+      "wifi_ssid": "AirPortExtreme",
+      "wifi_password": "Flash255"
+    },
+    {
+      "board_id": 2,
+      "firmwareUpdate": false,
+      "loopDelay": 10,
+      "offset": -598696,
+      "scale": -25.353687,
+      "wifi_ssid": "AirPortExtreme",
+      "wifi_password": "Flash255"
+    },
+    {
+      "board_id": 3,
+      "firmwareUpdate": false,
+      "loopDelay": 10,
+      "offset": -598696,
+      "scale": -25.353687,
+      "wifi_ssid": "AirPortExtreme",
+      "wifi_password": "Flash255"
+    },
+    {
+      "board_id": 4,
+      "firmwareUpdate": false,
+      "loopDelay": 10,
+      "offset": -598696,
+      "scale": -25.353687,
+      "wifi_ssid": "AirPortExtreme",
+      "wifi_password": "Flash255"
+    }
+  ]
 }

--- a/server/setup.php
+++ b/server/setup.php
@@ -7,31 +7,38 @@ if (!isset($_SESSION['logged_in'])) {
 
 $configFile = __DIR__ . '/settings.json';
 
-if ($_SERVER['REQUEST_METHOD'] === 'POST') {
-    $firmwareUpdate = isset($_POST['firmwareUpdate']);
-    $loopDelay = intval($_POST['loopDelay']);
-    $offset = floatval($_POST['offset']);
-    $scale  = floatval($_POST['scale']);
-    $ssid  = $_POST['wifi_ssid'] ?? '';
-    $pass  = $_POST['wifi_password'] ?? '';
-    $boardId = intval($_POST['board_id'] ?? 1);
+// load existing config
+$all = [];
+if (file_exists($configFile)) {
+    $all = json_decode(file_get_contents($configFile), true) ?: [];
+}
+if (!isset($all['boards'])) {
+    $all['boards'] = [];
+}
 
-    $all = [];
-    if (file_exists($configFile)) {
-        $all = json_decode(file_get_contents($configFile), true) ?: [];
-    }
-    if (!isset($all['boards'])) {
-        $all['boards'] = [];
-    }
-    $boardConfig = [
-        'board_id' => $boardId,
-        'firmwareUpdate' => $firmwareUpdate,
-        'loopDelay' => $loopDelay,
-        'offset' => $offset,
-        'scale' => $scale,
-        'wifi_ssid' => $ssid,
-        'wifi_password' => $pass
+function default_board($id) {
+    return [
+        'board_id' => $id,
+        'firmwareUpdate' => false,
+        'loopDelay' => 10,
+        'offset' => -598696,
+        'scale' => -25.353687,
+        'wifi_ssid' => '',
+        'wifi_password' => ''
     ];
+}
+
+// update configuration if form submitted
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $boardId = intval($_POST['board_id'] ?? 1);
+    $boardConfig = default_board($boardId);
+    $boardConfig['firmwareUpdate'] = isset($_POST['firmwareUpdate']);
+    $boardConfig['loopDelay'] = intval($_POST['loopDelay']);
+    $boardConfig['offset'] = floatval($_POST['offset']);
+    $boardConfig['scale'] = floatval($_POST['scale']);
+    $boardConfig['wifi_ssid'] = $_POST['wifi_ssid'] ?? '';
+    $boardConfig['wifi_password'] = $_POST['wifi_password'] ?? '';
+
     $updated = false;
     foreach ($all['boards'] as $i => $b) {
         if (($b['board_id'] ?? null) == $boardId) {
@@ -44,42 +51,18 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         $all['boards'][] = $boardConfig;
     }
     file_put_contents($configFile, json_encode($all, JSON_PRETTY_PRINT));
-    $message = 'Zapisano konfigurację.';
-} else {
-    if (file_exists($configFile)) {
-        $all = json_decode(file_get_contents($configFile), true);
-        $boardId = intval($_GET['board_id'] ?? 1);
-        $found = false;
-        if (isset($all['boards'])) {
-            foreach ($all['boards'] as $b) {
-                if (($b['board_id'] ?? null) == $boardId) {
-                    $firmwareUpdate = $b['firmwareUpdate'];
-                    $loopDelay = $b['loopDelay'];
-                    $offset = $b['offset'];
-                    $scale  = $b['scale'];
-                    $ssid   = $b['wifi_ssid'] ?? '';
-                    $pass   = $b['wifi_password'] ?? '';
-                    $found = true;
-                    break;
-                }
-            }
+    $message = 'Zapisano konfigurację dla płytki ' . $boardId . '.';
+}
+
+// prepare board configs for display
+$boards = [];
+for ($id = 1; $id <= 4; $id++) {
+    $boards[$id] = default_board($id);
+    foreach ($all['boards'] as $b) {
+        if (($b['board_id'] ?? null) == $id) {
+            $boards[$id] = array_merge($boards[$id], $b);
+            break;
         }
-        if (!$found) {
-            $firmwareUpdate = false;
-            $loopDelay = 10;
-            $offset = -598696;
-            $scale  = -25.353687;
-            $ssid = '';
-            $pass = '';
-        }
-    } else {
-        $firmwareUpdate = false;
-        $loopDelay = 10;
-        $offset = -598696;
-        $scale  = -25.353687;
-        $ssid = '';
-        $pass = '';
-        $boardId = intval($_GET['board_id'] ?? 1);
     }
 }
 ?>
@@ -88,40 +71,44 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 <head>
     <meta charset="UTF-8">
     <title>Ustawienia</title>
+    <style>
+        form { margin-bottom: 2rem; padding: 1rem; border: 1px solid #ccc; }
+    </style>
 </head>
 <body>
 <?php if(isset($message)) echo "<p>$message</p>"; ?>
+<?php foreach($boards as $b): ?>
 <form method="post">
+    <h3>Płytka <?php echo $b['board_id']; ?></h3>
     <label>
-        <input type="checkbox" name="firmwareUpdate" <?php if($firmwareUpdate) echo 'checked'; ?>>
+        <input type="checkbox" name="firmwareUpdate" <?php if($b['firmwareUpdate']) echo 'checked'; ?>>
         firmwareUPDATE
     </label><br>
     <label>Delay pętli:
         <select name="loopDelay">
-            <option value="10" <?php if($loopDelay==10) echo 'selected'; ?>>10s</option>
-            <option value="30" <?php if($loopDelay==30) echo 'selected'; ?>>30s</option>
-            <option value="60" <?php if($loopDelay==60) echo 'selected'; ?>>60s</option>
-            <option value="600" <?php if($loopDelay==600) echo 'selected'; ?>>600s</option>
-            <option value="3600" <?php if($loopDelay==3600) echo 'selected'; ?>>3600s</option>
+            <option value="10" <?php if($b['loopDelay']==10) echo 'selected'; ?>>10s</option>
+            <option value="30" <?php if($b['loopDelay']==30) echo 'selected'; ?>>30s</option>
+            <option value="60" <?php if($b['loopDelay']==60) echo 'selected'; ?>>60s</option>
+            <option value="600" <?php if($b['loopDelay']==600) echo 'selected'; ?>>600s</option>
+            <option value="3600" <?php if($b['loopDelay']==3600) echo 'selected'; ?>>3600s</option>
         </select>
     </label><br>
     <label>Offset:
-        <input type="text" name="offset" value="<?php echo htmlspecialchars($offset); ?>">
+        <input type="text" name="offset" value="<?php echo htmlspecialchars($b['offset']); ?>">
     </label><br>
     <label>Scale:
-        <input type="text" name="scale" value="<?php echo htmlspecialchars($scale); ?>">
+        <input type="text" name="scale" value="<?php echo htmlspecialchars($b['scale']); ?>">
     </label><br>
     <label>WiFi SSID:
-        <input type="text" name="wifi_ssid" value="<?php echo htmlspecialchars($ssid); ?>">
+        <input type="text" name="wifi_ssid" value="<?php echo htmlspecialchars($b['wifi_ssid']); ?>">
     </label><br>
     <label>WiFi Hasło:
-        <input type="password" name="wifi_password" value="<?php echo htmlspecialchars($pass); ?>">
+        <input type="password" name="wifi_password" value="<?php echo htmlspecialchars($b['wifi_password']); ?>">
     </label><br>
-    <label>ID płytki:
-        <input type="number" name="board_id" value="<?php echo htmlspecialchars($boardId); ?>" min="1">
-    </label><br>
-    <button type="submit">SETUP</button>
+    <input type="hidden" name="board_id" value="<?php echo $b['board_id']; ?>">
+    <button type="submit">Zapisz</button>
 </form>
+<?php endforeach; ?>
 <p><a href="index2.php">Powrót</a></p>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- extend `settings.json` to hold four board configs
- fetch per-board settings in the ESP32 sketch
- update setup script to modify individual board entries
- keep charts in a two column layout on all screens
- document new config file layout in `README`

## Testing
- `php -l server/setup.php`
- `php -l server/index2.php`
- `php -l server/data.php`
- `php -l server/api/add.php`


------
https://chatgpt.com/codex/tasks/task_e_686c8c28c28483209347cf48a850e297